### PR TITLE
Quick PoC to pass through a configurable header for authentication

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -177,6 +177,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
         // google-api-client doesn't use the Swagger auth, because it uses Google Credential directly (HttpRequestInitializer)
         if (!("google-api-client".equals(getLibrary()) || REST_ASSURED.equals(getLibrary()))) {
+            supportingFiles.add(new SupportingFile("auth/HeaderPassThroughAuth.mustache", authFolder, "HeaderPassThroughAuth.java"));
             supportingFiles.add(new SupportingFile("auth/HttpBasicAuth.mustache", authFolder, "HttpBasicAuth.java"));
             supportingFiles.add(new SupportingFile("auth/ApiKeyAuth.mustache", authFolder, "ApiKeyAuth.java"));
             supportingFiles.add(new SupportingFile("auth/OAuth.mustache", authFolder, "OAuth.java"));

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -62,6 +62,7 @@ import java.util.Map.Entry;
 import java.util.TimeZone;
 
 import {{invokerPackage}}.auth.Authentication;
+import {{invokerPackage}}.auth.HeaderPassThroughAuth;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 import {{invokerPackage}}.auth.OAuth;
@@ -120,10 +121,8 @@ public class ApiClient {
         setUserAgent("Java-SDK");
 
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}
-        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
-        authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
-        authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
+        authentications = new HashMap<String, Authentication>();
+        authentications.put("{{name}}", new HeaderPassThroughAuth());
         // Prevent the authentications from being modified.
         authentications = Collections.unmodifiableMap(authentications);
     }
@@ -248,6 +247,20 @@ public class ApiClient {
             }
         }
         throw new RuntimeException("No OAuth2 authentication configured!");
+    }
+
+    /**
+    * Helper method to set the header key name to pass through for HeaderPassThroughAuth authentication.
+    * @param headerToPassThrough the header key name to pass through
+    */
+    public void setHeaderToPassThrough(String headerToPassThrough) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HeaderPassThroughAuth) {
+                ((HeaderPassThroughAuth) auth).setHeaderToPassThrough(headerToPassThrough);
+                return;
+            }
+        }
+        throw new RuntimeException("No HeaderPassThroughAuth authentication configured!");
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/auth/HeaderPassThroughAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/auth/HeaderPassThroughAuth.mustache
@@ -1,0 +1,38 @@
+package {{invokerPackage}}.auth;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+
+{{>generatedAnnotation}}
+public class HeaderPassThroughAuth implements Authentication {
+
+    private String headerToPassThrough;
+
+    public String getHeaderToPassThrough() {
+        return headerToPassThrough;
+    }
+
+    public void setHeaderToPassThrough(String headerToPassThrough) {
+        this.headerToPassThrough = headerToPassThrough;
+    }
+
+    @Override
+    public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams) {
+        if (headerToPassThrough == null) {
+            return;
+        }
+
+        ServletRequestAttributes sra = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        HttpServletRequest req = sra.getRequest();
+
+        String headerValue = req.getHeader(headerToPassThrough);
+
+        if (headerValue != null) {
+            headerParams.set(headerToPassThrough, headerValue);
+        }
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -215,7 +215,19 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>${spring-web-version}</version>
+            <version>${spring-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax-servlet-version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- JSON processing: jackson -->
@@ -287,8 +299,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.17</swagger-annotations-version>
-        <spring-web-version>4.3.9.RELEASE</spring-web-version>
+        <spring-version>5.0.9.RELEASE</spring-version>
         <jackson-version>2.8.9</jackson-version>
+        <javax-servlet-version>3.1.0</javax-servlet-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}


### PR DESCRIPTION
This change adds a new class for passing through a header value from the inbound request to the outbound request.

One issue is that we'd need to make sure the `RequestContextHolder` returns the correct `HttpServletRequest` value whenever the client is used off the primary request thread.  Spring magic (e.g. `RequestContextFilter.setThreadContextInheritable` can help if we're diligent about staying within the Spring world, but has risks around either leaking data or omitting it.

Alternatively, we can change the generation template to create client instances as Spring `prototypes` or via a factory, and inject the actual header value into each instance, scoped to the request.  The various instances look cheap to create, so there's little worry on the performance side, though users would still need to know to NOT construct one of these clients on a non-request thread, as it still lacks the `HttpServletRequest` context needed to initialize the client.  I'm tending to prefer this approach instead, if only for the security benefits and lack of surprise.